### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,9 @@
     "autoload": {
         "psr-4": { "Octopush\\Bundle\\SMSBundle\\": "" }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/umpirsky/sms-api-php.git"
-        }
-    ],
     "require": {
         "php": ">=5.4",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "octopush/sms-api": "dev-feature/2.0"
+        "octopush/sms-api": "dev-master"
     }
 }


### PR DESCRIPTION
We should tag a new release of sms-api-php and depend on it.

See https://github.com/octopush/sms-api-php/issues/2
